### PR TITLE
Add cleanup on init again. #295

### DIFF
--- a/tests/cSharp/__init__.py
+++ b/tests/cSharp/__init__.py
@@ -13,3 +13,11 @@ def client():
             db.create_all()
             # Tests will be executed on the test_client object
             yield test_client
+    cleanup()
+
+
+def cleanup():
+    path = "./example-challenges/c-sharp-challenges"
+    for dirname in os.listdir(path):
+        if os.path.isdir(path + '/' + dirname) and dirname != "Median":
+            shutil.rmtree(path + '/' + dirname)


### PR DESCRIPTION
Turns out the init cleanup method is a must when tests fail and their cleanup doesn't start. Thats why I added the cleanup again. #295 